### PR TITLE
Binding description

### DIFF
--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -87,9 +87,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <div type="level3">
       <head>Cover</head>
        <p>In the
-             <tag>decoNote type="Cover"</tag>, using the <ref target="keywordsIntro">keywords</ref>,
+             <tag>decoNote type="Cover"</tag> you can describe the covering of the binding.
+             <!--If it covers only the spine and the back edge of the boards use the <att>key</att> quarterCover to encode it.-->
+             The attribute <att>color</att> is available
+             and using <ref target="keywordsIntro">keywords</ref>,
              you can record the presence of an additional leather patch and describe the the blind-tooling decoration.
              It is useful to specify where the decoration is found (boards, edges, turn-ins, spine).
+             <!--Additional keywords are available to describe the aspect of the turn-ins.-->
       </p>
      </div>
 
@@ -130,21 +134,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      </div>
      <div type="level3">
        <head>Endleaves</head>
-         <p>Endleaves are leaves intended to protect the text leaves. Therefore they are placed at the beginning and/or at the end of the text. Endleaves can be extra leaves added by the binder during the sewing or they can be leaves belonging to the first or last quire, left blank by the scribe in order to protect the text. Later, endleaves can be filled with notes, additional texts, ecc.
-If an endleaf is pasted to the inside of a board it's called pastedown and it is important to record its position in relation with the turn-ins.
-Inside the <tag>decoNote type="Endleaves"</tag> you can add the attribute <att>pastedown</att>
-and choose up to three values prompted by the schema in order to describe the position of the pastedown. Inside the
-             <tag>decoNote type="Endleaves"</tag>
-             you can add the attribute <att>pastedown</att>
-             and choose up to three values prompted by the schema
-             in order to describe the position of the pastedown (if present).
-            See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:
-             <egXML xmlns="http://www.tei-c.org/ns/Examples">
-             <decoNote xml:id="b11" type="EndLeaves" pastedown="L OTI">
-The inner surface of the front board is covered with paper. Traces of paper are found also on the external surface.
-</decoNote>
-</egXML>
-
+         <p>Endleaves are leaves intended to protect the text leaves. Therefore they are placed at the beginning and/or at the end of the text. Endleaves are left blank but later they can be used for marginal writings.
+           If an endleaf is pasted to the inside of a board it's called pastedown and it is important to record its position in relation with the turn-ins.
+           Inside the <tag>decoNote type="Endleaves"</tag> you can add the attribute <att>pastedown</att>
+           and choose up to three values prompted by the schema in order to describe the position of the pastedown.
+           See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:
+           <egXML xmlns="http://www.tei-c.org/ns/Examples">
+           <decoNote xml:id="b11" type="EndLeaves" pastedown="L OTI">
+           The inner surface of the front board is covered with paper. Traces of paper are found also on the external surface.
+           </decoNote>
+           </egXML>
          </p>
      </div>
 

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -88,12 +88,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <head>Cover</head>
        <p>In the
              <tag>decoNote type="Cover"</tag> you can describe the covering of the binding.
-             <!--If it covers only the spine and the back edge of the boards use the <att>key</att> quarterCover to encode it.-->
+             If it covers only the spine and the back edge of the boards use the <att>key</att> quarterCover to encode it.
              The attribute <att>color</att> is available
              and using <ref target="keywordsIntro">keywords</ref>,
              you can record the presence of an additional leather patch and describe the the blind-tooling decoration.
              It is useful to specify where the decoration is found (boards, edges, turn-ins, spine).
-             <!--Additional keywords are available to describe the aspect of the turn-ins.-->
+             Additional keywords are available to describe the aspect of turn-ins corners.
       </p>
      </div>
 
@@ -104,15 +104,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              requires to type a number, which has to be equal to the number
              of sewing stations (not to the number of pairs of sewing stations).
              See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:
-<egXML xmlns="http://www.tei-c.org/ns/Examples">
-<decoNote xml:id="b6" type="SewingStations">4</decoNote>
-</egXML>
+            <egXML xmlns="http://www.tei-c.org/ns/Examples">
+              <decoNote xml:id="b6" type="SewingStations">4</decoNote>
+            </egXML>
          </p>
 
          <p>A further description of the sewing is possible
-             within a general <gi>decoNote</gi>. Here, if identified, you can specify with keywords the origin of sewing thread and the sewing pattern,
-             following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>.
-             Sewing stations are numbered starting from the head (first sewing station, second sewing station, third sewing station, etc.).
+             within a general <gi>decoNote</gi>. Sewing stations are numbered starting from the head (first sewing station, second sewing station, third sewing station, etc.).
+             Here, if identified, you can specify with keywords the origin of sewing thread. <!--and the sewing pattern,
+             following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>.-->
          </p>
      </div>
      <div type="level3">
@@ -125,17 +125,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              See for example <ref type="BM" target="SHOr404">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 404</ref>:
              <egXML xmlns="http://www.tei-c.org/ns/Examples">
                <decoNote xml:id="b5" type="Endbands" color="red white">
-  Narrow
-  <term key="slitBraid">slit-braid</term>
-  endbands and are sewn to the text block using a thread of animal origin. The headband is sewn starting from the upper board while the tailband is sewn starting from the lower board.
-  </decoNote>
-</egXML>
+                 Narrow
+                 <term key="slitBraid">slit-braid</term>
+                 endbands and are sewn to the text block using a thread of animal origin. The headband is sewn starting from the upper board while the tailband is sewn starting from the lower board.
+               </decoNote>
+             </egXML>
          </p>
      </div>
      <div type="level3">
-       <head>Endleaves</head>
-         <p>Endleaves are leaves intended to protect the text leaves. Therefore they are placed at the beginning and/or at the end of the text. Endleaves are left blank but later they can be used for marginal writings.
-           If an endleaf is pasted to the inside of a board it's called pastedown and it is important to record its position in relation with the turn-ins.
+       <head>Endleaves and Pastedowns</head>
+         <p>Endleaves are one or more leaves added at the front and/or back of the textblock for its protection.
+           Endleaves are frequently left blank or without pricking and ruling;
+           but they can be used for marginal writing.
+           A pastedown is an endleaf adhered to the inside of the front of back board and it is important to record its position in relation with the turn-ins.
            Inside the <tag>decoNote type="Endleaves"</tag> you can add the attribute <att>pastedown</att>
            and choose up to three values prompted by the schema in order to describe the position of the pastedown.
            See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -71,6 +71,127 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <p>You can always further specify this information within one
         of the <gi>decoNote</gi> elements within
         <gi>binding</gi>.</p>
-        </body>
+
+    <div type="level3">
+      <head>Boards</head>
+        <p>In the
+            <tag>decoNote type="Boards"</tag>
+            you can specify using keywords the wood type (if known) and
+            encode the presence of a textile inlay or of a mirror.
+        </p>
+    </div>
+
+    <div type="level3">
+      <head>Cover</head>
+       <p>In the
+             <tag>decoNote type="Cover"</tag>, using the keywords,
+             you can describe the the blind-tooling decoration
+             and record the presence of an additional leather patch.
+         </p>
+     </div>
+
+     <div type="level3">
+       <head>Sewing Stations</head>
+         <p>The
+             <tag>decoNote type="SewingStations"</tag>
+             requires to type a number, which has to be equal to the number
+             of sewing stations (not to the number of pairs of sewing stations).
+         </p>
+
+         <p>A further description of the sewing is possible
+             within a general <gi>decoNote</gi> with a progressive
+             <att>xml:id</att>. Here, if identified, you can specify with keywords the sewing pattern,
+             following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>
+             and the origin of sewing thread.
+         </p>
+     </div>
+     <div type="level3">
+       <head>Endbands</head>
+         <p>Inside the
+             <tag>decoNote type="Endbands"</tag>
+             you can use the attribute <att>color</att>
+             and keywords in order to specify
+             the endband type.
+         </p>
+     </div>
+     <div type="level3">
+       <head>Endleaves</head>
+         <p>Inside the
+             <tag>decoNote type="Endleaves"</tag>
+             you can add the attribute <att>pastedown</att>
+             and choose up to three values prompted by the schema
+             in order to describe the position of the pastedown (if present).
+         </p>
+     </div>
+
+     <div type="level3">
+       <head>Spine</head>
+        <p>Special caratheristics of the spine can be recorded in the
+        <tag>decoNote type="Spine"</tag>
+        like, for example, a series of
+        holes related to the presence of tackets.
+        </p>
+      </div>
+
+      <div type="level3">
+        <head>Fastening</head>
+         <p>You can describe fastenings or the remaining
+            traces of them in the <tag>decoNote type="Fastenings"</tag>
+         </p>
+     </div>
+
+     <div type="level3">
+       <head>Leather case (māḥdar)</head>
+       <p>Inside the
+           <tag>decoNote type="SlipCase"</tag>
+           you can record and describe the leather case (māḥdar) where the codex is kept.
+       </p>
+     </div>
+
+
+     <div type="level3">
+       <head>Other</head>
+         <p>Inside the
+             <tag>decoNote type="Other"</tag>
+             is possible to use keywords to record other features.</p>
+
+             <list>
+             <item>
+               <p>You can record the presence of parchment <val>guard</val>s, their position
+               and the technique of attachment.
+              </p>
+             </item>
+             <item>
+               <p>It is possible to describe bookmarks using <val>leafStringMark</val> or <val>LeafTabMark</val> keywords.</p>
+
+         <egXML xmlns="http://www.tei-c.org/ns/Examples">
+             <bindingDesc>
+                 <decoNote xml:id="b5" type="Other">
+                 <term key="leafStringMark"/>
+                 inserted in the the upper text prick of ff. 10, 20, ...
+                 </decoNote>
+             </bindingDesc>
+         </egXML>
+         <p>The leaf string marker is a bookmark made of one or several twisted threads, coloured or uncoloured, through a the leaf.
+         Examples:
+         image 1: leaf string marker inserted in the upper corner (MKMG 006)
+         image 2: leaf string marker inserted in the upper text prick (SSB-003)
+         image 3: leaf string marker inserted in the outer margin (MAKM-086b
+         </p>
+
+         <p>The leaf tab marker is a bookmark made of a small piece of textile inserted in the margin of a leaf.
+         Example:
+
+         <figure>
+           <graphic xml:id="g1" url="http://betamasaheft.eu/iiif/KY/013/KY-013_022.tif/info.json">
+             <desc>A leaf tab marker inserted in the outer margin</desc>
+           </graphic>
+         </figure>
+         </p>
+         </item>
+         </list>
+    </div>
+  
+</body>
     </text>
 </TEI>

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -20,6 +20,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
           <change who="PL" when="2018-04-30">first version of guidelines from Wiki</change>
           <change who="PL" when="2018-04-24">stub of page</change>
+          <change who="EDS" when="2019-01-08">content added</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -87,9 +88,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <head>Cover</head>
        <p>In the
              <tag>decoNote type="Cover"</tag>, using the <ref target="keywordsIntro">keywords</ref>,
-             you can describe the the blind-tooling decoration
-             and record the presence of an additional leather patch.
-         </p>
+             you can record the presence of an additional leather patch and describe the the blind-tooling decoration.
+             It is useful to specify where the decoration is found (boards, edges, turn-ins, spine).
+      </p>
      </div>
 
      <div type="level3">
@@ -105,9 +106,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          </p>
 
          <p>A further description of the sewing is possible
-             within a general <gi>decoNote</gi>. Here, if identified, you can specify with keywords the sewing pattern,
-             following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>
-             and the origin of sewing thread.
+             within a general <gi>decoNote</gi>. Here, if identified, you can specify with keywords the origin of sewing thread and the sewing pattern,
+             following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>.
+
          </p>
      </div>
      <div type="level3">
@@ -129,7 +130,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
      </div>
      <div type="level3">
        <head>Endleaves</head>
-         <p>Inside the
+         <p>Endleaves are leaves intended to protect the text leaves. Therefore they are placed at the beginning and/or at the end of the text. Endleaves can be extra leaves added by the binder during the sewing or they can be leaves belonging to the first or last quire, left blank by the scribe in order to protect the text. Later, endleaves can be filled with notes, additional texts, ecc.
+If an endleaf is pasted to the inside of a board it's called pastedown and it is important to record its position in relation with the turn-ins.
+Inside the <tag>decoNote type="Endleaves"</tag> you can add the attribute <att>pastedown</att>
+and choose up to three values prompted by the schema in order to describe the position of the pastedown. Inside the
              <tag>decoNote type="Endleaves"</tag>
              you can add the attribute <att>pastedown</att>
              and choose up to three values prompted by the schema
@@ -176,13 +180,12 @@ The inner surface of the front board is covered with paper. Traces of paper are 
              is possible to use <ref target="keywordsIntro">keywords</ref> from the specific
              sections of the <ref target="taxonomy">taxonomy</ref> to record other features.</p>
 
-             <list>
-             <item>
+
                <p>You can record the presence of parchment <val>guard</val>s, their position
                and the technique of attachment.
               </p>
-             </item>
-             <item>
+
+
                <p>It is possible to describe bookmarks using <val>leafStringMark</val> or <val>LeafTabMark</val> keywords.</p>
 
          <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -194,7 +197,8 @@ The inner surface of the front board is covered with paper. Traces of paper are 
              </bindingDesc>
          </egXML>
          <p>The leaf string marker is a bookmark made of one or several twisted threads, coloured or uncoloured, sewed through a the leaf.
-           It can be found in different positions as shown in the following examples (<ref type="figure" target="#g2"/> and <ref type="figure" target="#g3"/></p>)
+           It can be found in different positions as shown in the following examples (<ref type="figure" target="#g2"/> and <ref type="figure" target="#g3"/>)</p>
+
          <list>
          <item>
            <p>A leaf string marker inserted in the upper corner</p>
@@ -224,8 +228,8 @@ The inner surface of the front board is covered with paper. Traces of paper are 
            </graphic>
          </figure>
          </p>
-         </item>
-         </list>
+
+
     </div>
 </div>
 </body>

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -108,7 +108,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <p>A further description of the sewing is possible
              within a general <gi>decoNote</gi>. Here, if identified, you can specify with keywords the origin of sewing thread and the sewing pattern,
              following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>.
-
+             Sewing stations are numbered starting from the head (first sewing station, second sewing station, third sewing station, etc.).
          </p>
      </div>
      <div type="level3">

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -172,12 +172,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                  </decoNote>
              </bindingDesc>
          </egXML>
-         <p>The leaf string marker is a bookmark made of one or several twisted threads, coloured or uncoloured, through a the leaf.
-         Examples:
-         image 1: leaf string marker inserted in the upper corner (MKMG 006)
-         image 2: leaf string marker inserted in the upper text prick (SSB-003)
-         image 3: leaf string marker inserted in the outer margin (MAKM-086b
-         </p>
+         <p>The leaf string marker is a bookmark made of one or several twisted threads, coloured or uncoloured, sewed through a the leaf.
+           It can be found in different positions as shown in the following examples.</p>
+         <list>
+         <item>
+           <p>A leaf string marker inserted in the upper corner (MKMG 006)</p>
+         <figure>
+           <graphic xml:id="g2" url="http://betamasaheft.eu/iiif/MKMG/006/MKMG-006_055.tif/info.json">
+           </graphic>
+         </figure>
+         </item>
+         <item>
+         <p>A leaf string marker inserted in the upper text prick (SSB-003)</p>
+         <figure>
+           <graphic xml:id="g3" url="http://betamasaheft.eu/iiif/SSB/003/SSB-003_098.tif/info.json">
+           </graphic>
+         </figure>
+         </item>
+         <!--<item>
+           <p>image 3: leaf string marker inserted in the outer margin (MAKM-086b) </p>
+         </item>-->
+
+         </list>
 
          <p>The leaf tab marker is a bookmark made of a small piece of textile inserted in the margin of a leaf as shown in <ref type="figure" target="#g1"/>
 

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -173,17 +173,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              </bindingDesc>
          </egXML>
          <p>The leaf string marker is a bookmark made of one or several twisted threads, coloured or uncoloured, sewed through a the leaf.
-           It can be found in different positions as shown in the following examples.</p>
+           It can be found in different positions as shown in the following examples (<ref type="figure" target="#g2"/> and <ref type="figure" target="#g3"/></p>)
          <list>
          <item>
-           <p>A leaf string marker inserted in the upper corner (MKMG 006)</p>
+           <p>A leaf string marker inserted in the upper corner</p>
          <figure>
            <graphic xml:id="g2" url="http://betamasaheft.eu/iiif/MKMG/006/MKMG-006_055.tif/info.json">
            </graphic>
          </figure>
          </item>
          <item>
-         <p>A leaf string marker inserted in the upper text prick (SSB-003)</p>
+         <p>A leaf string marker inserted in the upper text prick</p>
          <figure>
            <graphic xml:id="g3" url="http://betamasaheft.eu/iiif/SSB/003/SSB-003_096.tif/info.json">
            </graphic>

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -185,7 +185,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <item>
          <p>A leaf string marker inserted in the upper text prick (SSB-003)</p>
          <figure>
-           <graphic xml:id="g3" url="http://betamasaheft.eu/iiif/SSB/003/SSB-003_098.tif/info.json">
+           <graphic xml:id="g3" url="http://betamasaheft.eu/iiif/SSB/003/SSB-003_096.tif/info.json">
            </graphic>
          </figure>
          </item>

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -72,6 +72,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         of the <gi>decoNote</gi> elements within
         <gi>binding</gi>.</p>
 
+<div type="level2">
+  <p>Here are some examples of how to use typed decoNote elements to provide specific information</p>
     <div type="level3">
       <head>Boards</head>
         <p>In the
@@ -84,7 +86,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <div type="level3">
       <head>Cover</head>
        <p>In the
-             <tag>decoNote type="Cover"</tag>, using the keywords,
+             <tag>decoNote type="Cover"</tag>, using the <ref target="keywordsIntro">keywords</ref>,
              you can describe the the blind-tooling decoration
              and record the presence of an additional leather patch.
          </p>
@@ -96,11 +98,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              <tag>decoNote type="SewingStations"</tag>
              requires to type a number, which has to be equal to the number
              of sewing stations (not to the number of pairs of sewing stations).
+             See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:
+<egXML xmlns="http://www.tei-c.org/ns/Examples">
+<decoNote xml:id="b6" type="SewingStations">4</decoNote>
+</egXML>
          </p>
 
          <p>A further description of the sewing is possible
-             within a general <gi>decoNote</gi> with a progressive
-             <att>xml:id</att>. Here, if identified, you can specify with keywords the sewing pattern,
+             within a general <gi>decoNote</gi>. Here, if identified, you can specify with keywords the sewing pattern,
              following Bozzacchi's classification <ref target="https://www.zotero.org/groups/358366/ethiostudies/items/itemKey/2968T6TC/q/bozzacchi"></ref>
              and the origin of sewing thread.
          </p>
@@ -112,6 +117,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              you can use the attribute <att>color</att>
              and keywords in order to specify
              the endband type.
+             See for example <ref type="BM" target="SHOr404">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 404</ref>:
+             <egXML xmlns="http://www.tei-c.org/ns/Examples">
+               <decoNote xml:id="b5" type="Endbands" color="red white">
+  Narrow
+  <term key="slitBraid">slit-braid</term>
+  endbands and are sewn to the text block using a thread of animal origin. The headband is sewn starting from the upper board while the tailband is sewn starting from the lower board.
+  </decoNote>
+</egXML>
          </p>
      </div>
      <div type="level3">
@@ -121,6 +134,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
              you can add the attribute <att>pastedown</att>
              and choose up to three values prompted by the schema
              in order to describe the position of the pastedown (if present).
+            See for example <ref type="BM" target="SHOr405">Hamburg, State and University Library Hamburg Carl von Ossietzky, Cod. Orient. 405</ref>:
+             <egXML xmlns="http://www.tei-c.org/ns/Examples">
+             <decoNote xml:id="b11" type="EndLeaves" pastedown="L OTI">
+The inner surface of the front board is covered with paper. Traces of paper are found also on the external surface.
+</decoNote>
+</egXML>
+
          </p>
      </div>
 
@@ -153,7 +173,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
        <head>Other</head>
          <p>Inside the
              <tag>decoNote type="Other"</tag>
-             is possible to use keywords to record other features.</p>
+             is possible to use <ref target="keywordsIntro">keywords</ref> from the specific
+             sections of the <ref target="taxonomy">taxonomy</ref> to record other features.</p>
 
              <list>
              <item>
@@ -206,7 +227,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          </item>
          </list>
     </div>
-
+</div>
 </body>
     </text>
 </TEI>

--- a/pages/bindingDescription.xml
+++ b/pages/bindingDescription.xml
@@ -179,8 +179,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          image 3: leaf string marker inserted in the outer margin (MAKM-086b
          </p>
 
-         <p>The leaf tab marker is a bookmark made of a small piece of textile inserted in the margin of a leaf.
-         Example:
+         <p>The leaf tab marker is a bookmark made of a small piece of textile inserted in the margin of a leaf as shown in <ref type="figure" target="#g1"/>
 
          <figure>
            <graphic xml:id="g1" url="http://betamasaheft.eu/iiif/KY/013/KY-013_022.tif/info.json">
@@ -191,7 +190,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          </item>
          </list>
     </div>
-  
+
 </body>
     </text>
 </TEI>


### PR DESCRIPTION
1. Extended the description of the decoNotes available in bindingDesc with dedicated paragraphs:
- boards 
- cover
- sewing stations
- endbands
- endleaves
- spine
- slip case (leather case)
- other (parchment guards, bookmarks...)

2. Specified what can be encoded in each decoNote and which keywords are available.

3. The part concerning bookmarks is a resume of what discussed in the issue: https://github.com/BetaMasaheft/Documentation/issues/972

4. The part concerning the slip case (leather case) is still discussed in the issue:
https://github.com/BetaMasaheft/Documentation/issues/970



