### PR TITLE
Update Guidelines Incipit and Explicit

### DIFF
--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -27,10 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <head>explicit</head>
             <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
                to help to realize the extention and completeness of a texts or its parts.  They should contain no more than 20 to 30 words and should 
-               focus on meaningful and substantial last phrases of the text proper. Quotation of explicits should preferably not include common 
-               formulas and eulogies unless there is no special reason to do so, as it may be relevant nevertheless to distinguish different versions or 
-               to record commissioners or other details that may be worth being encoded. When a text ends ex abrupto, it should be mentioned in a 
-               note and the final words should be quoted.</p>
+               focus on meaningful and substantial last phrases of the text proper. most common formulas and eulogies can be omitted and then should 
+               be marked as a gap and ellipsis. When a text ends ex abrupto, it should be mentioned in a note and the final words should be quoted.</p>
          </div>
       </body>
    </text>

--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -25,10 +25,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="explicit">
          <div>
             <head>explicit</head>
-            <p>Explicits are meant to give the user an impression of the texts included and help to navigate in a manuscript. They should 
-               contain no more than 20 to 30 words and should focus on the most meaningful and substantial last phrases of each text part. 
-               They should not include religious formulas, eulogies or later additions. Colophons are better to be recorded separately as 
-               colophon.</p>
+            <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
+               to help to realize the extention and completeness of a texts or its parts.  They should contain no more than 20 to 30 words and should 
+               focus on meaningful and substantial last phrases of the text proper. Quotation of explicits should preferably not include common 
+               formulas and eulogies unless there is no special reason to do so, as it may be relevant nevertheless to distinguish different versions or 
+               to record commissioners or other details that may be worth being encoded. When a text ends ex abrupto, it should be mentioned in a 
+               note and the final words should be quoted.</p>
          </div>
       </body>
    </text>

--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -25,7 +25,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="explicit">
          <div>
             <head>explicit</head>
-            <p/>
+            <p>Explicits are meant to give the user an impression of the texts included and help to navigate in a manuscript. They should 
+               contain no more than 20 to 30 words and should focus on the most meaningful and substantial last phrases of each text part. 
+               They should not include religious formulas, eulogies or later additions. Colophons are better to be recorded separately as 
+               colophon.</p>
          </div>
       </body>
    </text>

--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -25,8 +25,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="explicit">
          <div>
             <head>explicit</head>
-            <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
-               to help to realize the extention and completeness of a texts or its parts.  They should contain no more than 20 to 30 words and should 
+            <p>Quoting explicits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
+               to help to realize the extention and completeness of a texts or its parts. They should contain no more than 20 to 30 words and should 
                focus on meaningful and substantial last phrases of the text proper. Most common formulas and eulogies can be omitted and then should 
                be marked as a gap and ellipsis. When a text ends ex abrupto, it should be mentioned in a note and the final words should be quoted.</p>
          </div>

--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -25,10 +25,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="explicit">
          <div>
             <head>explicit</head>
-            <p>Quoting explicits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
-               to help to realize the extention and completeness of a texts or its parts. They should contain no more than 20 to 30 words and should 
-               focus on meaningful and substantial last phrases of the text proper. Most common formulas and eulogies can be omitted and then should 
-               be marked as a gap and ellipsis. When a text ends ex abrupto, it should be mentioned in a note and the final words should be quoted.</p>
+            <p>The purpose of quoting explicits is to describe the content of the manuscript, i.e. to help identify the texts or their parts, and to 
+               indicate the extent and completeness of the texts or their parts. They should not exceed 20 to 30 words and should concentrate on 
+               meaningful and substantial phrases from the end of the text itself. Most common formulas and eulogies may be omitted, and should 
+               be marked as gaps and ellipses. If a text ends ex abrutto, this should be mentioned in a note and the last words should be quoted.</p>
          </div>
       </body>
    </text>

--- a/elements/explicit.xml
+++ b/elements/explicit.xml
@@ -27,7 +27,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <head>explicit</head>
             <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
                to help to realize the extention and completeness of a texts or its parts.  They should contain no more than 20 to 30 words and should 
-               focus on meaningful and substantial last phrases of the text proper. most common formulas and eulogies can be omitted and then should 
+               focus on meaningful and substantial last phrases of the text proper. Most common formulas and eulogies can be omitted and then should 
                be marked as a gap and ellipsis. When a text ends ex abrupto, it should be mentioned in a note and the final words should be quoted.</p>
          </div>
       </body>

--- a/elements/incipit.xml
+++ b/elements/incipit.xml
@@ -19,15 +19,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </fileDesc>
       <revisionDesc>
          <change who="PL" when="2018-04-24">stub of page</change>
+         <change who="CH" when="2023-07-12">Added definition</change>
       </revisionDesc>
    </teiHeader>
    <text>
       <body xml:id="incipit">
          <div>
             <head>incipit</head>
-            <p>Incipits are meant to give the user an impression of the texts included and help to navigate in a manuscript. They should 
-               contain no more than 20 to 30 words and should focus on the most meaningful and substantial phrases of the beginning of each text part
-               and should exclude religious formulas or eulogies. </p>
+            <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
+               to help to realize the extention and completeness of the texts or its parts. They should contain no more than 20 to 30 words and should 
+               focus on meaningful and substantial phrases of the beginning of the text proper. Quotation of incipits should preferably not include common 
+               formulas or eulogies unless there is no special reason to do so, as it may be relevant nevertheless to distinguish between different versions 
+               or to record commissioners or other details that may be worth being encoded. When a text starts ex abrupto, it should be mentioned in a note
+               and the initial words should be quoted.</p>
          </div>
       </body>
    </text>

--- a/elements/incipit.xml
+++ b/elements/incipit.xml
@@ -26,11 +26,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="incipit">
          <div>
             <head>incipit</head>
-            <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
-               to help to realize the extention and completeness of the texts or its parts. They should contain no more than 20 to 30 words and should 
-               focus on meaningful and substantial phrases of the beginning of the text proper. Most common formulas and eulogies can be omitted 
-               and then should be marked as a gap and ellipsis. When a text starts ex abrupto, it should be mentioned in a note and the initial words 
-               should be quoted.</p>
+            <p>The purpose of quoting incipits is to describe the content of the manuscript, i.e. to help identify the texts or their parts, and to 
+               indicate the extent and completeness of the texts or their parts. They should not exceed 20 to 30 words and should concentrate on 
+               meaningful and substantial phrases from the beginning of the text itself. Most common formulas and eulogies may be omitted and 
+               should be marked as gaps and ellipses. If a text begins ex abrutto, this should be mentioned in a note and the first words should be 
+               quoted.</p>
          </div>
       </body>
    </text>

--- a/elements/incipit.xml
+++ b/elements/incipit.xml
@@ -25,7 +25,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <body xml:id="incipit">
          <div>
             <head>incipit</head>
-            <p/>
+            <p>Incipits are meant to give the user an impression of the texts included and help to navigate in a manuscript. They should 
+               contain no more than 20 to 30 words and should focus on the most meaningful and substantial phrases of the beginning of each text part
+               and should exclude religious formulas or eulogies. </p>
          </div>
       </body>
    </text>

--- a/elements/incipit.xml
+++ b/elements/incipit.xml
@@ -28,10 +28,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <head>incipit</head>
             <p>Quoting incipits serves the purpose of the description of the manuscript's content e.g. to help to identify the texts or their parts and 
                to help to realize the extention and completeness of the texts or its parts. They should contain no more than 20 to 30 words and should 
-               focus on meaningful and substantial phrases of the beginning of the text proper. Quotation of incipits should preferably not include common 
-               formulas or eulogies unless there is no special reason to do so, as it may be relevant nevertheless to distinguish between different versions 
-               or to record commissioners or other details that may be worth being encoded. When a text starts ex abrupto, it should be mentioned in a note
-               and the initial words should be quoted.</p>
+               focus on meaningful and substantial phrases of the beginning of the text proper. Most common formulas and eulogies can be omitted 
+               and then should be marked as a gap and ellipsis. When a text starts ex abrupto, it should be mentioned in a note and the initial words 
+               should be quoted.</p>
          </div>
       </body>
    </text>


### PR DESCRIPTION
I updated the guidelines concerning the incipits and explicits as discussed recently in our latest webmeeting. I am not sure, whether the phrase on colophons is useful or should deleted or extended. It might be appropriate to refer to the subpage "colophon", but I did not know, how I can indicate it in a `<ref>`.