### PR TITLE
guidelines for xinclude

### DIFF
--- a/pages/include.xml
+++ b/pages/include.xml
@@ -63,6 +63,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </p>
                 <p>You can include in files which are included, but please do not go deeper with folders than this order, just keep them all in the same folder, so that the relative path 
                 in <att>href</att> can be simply the filename.</p>
+                <p>IMPORTANT: if you are using the <gi>xi:include</gi> for your transcription and  the main manuscript record already contains a <gi>text</gi> element, you must (1) remove the <gi>text</gi> and <gi>body</gi> tags in the transkribusText.xml file, and (2) insert the  relevant <gi>xi:include</gi> element inside of the <gi>text</gi> element of your main file, cp. <ref target="https://github.com/BetaMasaheft/Manuscripts/commit/d32eeee5dd035986ca469fcafb3ab6f362b05fb6">this fix for an example</ref>.</p>
                 <p>Now, there are some qui-pro-quos. For example, validation will only be run from the main file. If you are working on any part you should look at errors
                 report in the main file. Also, Atom does not support this.</p>
             </div>

--- a/pages/transcriptionTranskribus.xml
+++ b/pages/transcriptionTranskribus.xml
@@ -69,6 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
               <p>When adding this transcription to a record, please add a <gi>sourceDesc</gi> <gi>p</gi>aragraph about the fact that the transcription is done with Transkribus
                   and add a <gi>change</gi> element detailing the transcription work carried out (corrected, not corrected, precision declared by the model, who has done the alignment and when, etc.).
                   It will also be useful to other users to add a <gi>note</gi> about the status of the transcription.</p>
+              <p>IMPORTANT: if you are using the <gi>xi:include</gi> for your transcription and  the main manuscript record already contains a <gi>text</gi> element, you must (1) remove the <gi>text</gi> and <gi>body</gi> tags in the transkribusText.xml file, and (2) insert the  relevant <gi>xi:include</gi> element inside of the <gi>text</gi> element of your main file.</p>
           </div>
           
           <div type="level3">


### PR DESCRIPTION
@HelenaSabel has brought to my attention that we have files with two `text `elements, as a result of one `text `element produced by the cataloguer and another being the result of xi:including a transcription.
Since only one text element should be allowed please pay attention that if there is already a text present, the included text should be inserted inside of the existing `text `element, and be cleaned of its own `text `and `body `tags. I have added this to the Guidelines. https://github.com/BetaMasaheft/Manuscripts/commit/d32eeee5dd035986ca469fcafb3ab6f362b05fb6