### PR TITLE
Update Guideline (replace 'texual unit')

### DIFF
--- a/pages/ArtThemes.xml
+++ b/pages/ArtThemes.xml
@@ -21,7 +21,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="DR" when="2018-05-02">Updated examples and fixed links</change>
          <change who="DR" when="2019-04-10">Included clarifications on art themes and caption encoding from issue 954, encoded lists,
          added paragraph on relations</change>
-         <change who="DR" when="2019-04-26">Specified use of ecrm:P129_is_about</change></revisionDesc>
+         <change who="DR" when="2019-04-26">Specified use of ecrm:P129_is_about</change>
+         <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
+      </revisionDesc>
    </teiHeader>
    <text>
 
@@ -58,7 +60,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
   British English;
      </item>
   <item>
-     b) include Ge'ez
+     b) include Gǝʾǝz
   title;
   </item>
   <item>
@@ -85,7 +87,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
   Ethiopian tradition, provide a brief description of the features of
   each typology.</p>
             <p>In addition to this basic information you may choose to provide
-  references to person, places and textual units IDs that inform the content
+  references to Persons, Places, Works and Narrative units that inform the content
   of the ATID (e.g The Crucifixion will include a
   reference to the Gospels) and/or, where possible, to the relevant
   passages of that work with <att>cRef</att>:

--- a/pages/ColophSupplTit.xml
+++ b/pages/ColophSupplTit.xml
@@ -21,6 +21,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <change who="PL" when="2019-06-28">first version from
         https://github.com/BetaMasaheft/Documentation/issues/946 and related issues, examples from
         document provided by Denis Nosnitsin and Dorothea Reule.</change>
+      <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
     </revisionDesc>
   </teiHeader>
   <text>
@@ -332,7 +333,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </explicit>
           </msItem>
         </egXML>
-        <p>In here the encoder is declaring the relation between the <gi>msItem</gi> and a textual unit twice, 
+        <p>In here the encoder is declaring the relation between the <gi>msItem</gi> and a Work twice, 
           once declaring an incipit, once not, and then also adding the incipit, which may contain the title again. There is no need to do all this, 
         it is enough to either
         <list><item>add the type <val>inscription</val> to the <gi>title</gi></item>

--- a/pages/Documents.xml
+++ b/pages/Documents.xml
@@ -20,13 +20,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
           <change who="PL" when="2018-07-20">first version of guidelines from Wiki</change>
             <change who="PL" when="2019-02-28">updated with examples</change>
+            <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body xml:id="Documents">
     <head>Documentary texts</head>
-<p>Texts which are not <ref target="definitionWorks">textual units</ref>
-occur often in manuscripts as <ref target="additionsVaria">additions</ref>.
+<p>Texts which are not <ref target="definitionWorks">Works</ref>
+occur often in manuscripts as <ref target="additionsVaria">Additions</ref>.
 That is why the list of types for these texts is in the
 <ref target="http://betamasaheft.eu/authority-files/list">Taxonomy</ref> under 'Additions'.</p>
             <p>Please, make sure you encode these texts correctly according to their actual
@@ -62,15 +63,16 @@ known and you wish to encode.</p>
 <p>There will be cases when it is only worth adding a value to <att>type</att> in <gi>desc</gi>,
 cases in which
 an association to a Narrative Unit is all that can be done, and cases in which the two
-might be very similar.</p>
+might be very similar.</p><!-- What 'two'? 'Narrative Unit and Addition' or 'Narrative Unit and Work'? -->
 <p>While the value of <att>type</att> in <gi>desc</gi> is only providing a useful
 grouping keyword from the taxonomy,
-the identification with a Textual Unit or Narrative Unit specifies that the current text is an <!--what?--></p>
+the identification with a Work or Narrative Unit specifies that the current text is an <!--what?--></p>
 <p>In the same way in which a document in a quaternary stratum
-   can be associated with a Narrative Unit, a quaternary stratum content
+    can be associated with a Narrative Unit, a quaternary stratum content (independent content, not-independent material,
+    autonomous writing project) 
   which can be identified with a stable content
   can be referenced in this same way,
-  like in <ref type="BM" target="BLorient481">London, British Library, BL Orient 481</ref></p>
+  like in <ref type="BM" target="BLorient481">London, British Library, BL Orient 481</ref>.</p>
 <egXML xmlns="http://www.tei-c.org/ns/Examples">
   <item xml:id="a15">
     <locus target="#92r"/>
@@ -79,10 +81,10 @@ the identification with a Textual Unit or Narrative Unit specifies that the curr
   </item>
 </egXML>
 <p>Here you will notice also how assigning a value to <att>type</att> in <gi>desc</gi>
-is different from identifying it with a Textual or Narrative Unit</p>
+is different from identifying it with a Work or Narrative Unit.</p>
 <p>If a document is the main content of a manuscript,
   it can be encoded in the same way as other main contents in <gi>msContents</gi>. If it
-  is not an identifiable Textual Unit,
+  is not an identifiable part of a Work,
 it might also be assigned a <ref target="narrativeUnits">Narrative Unit</ref> identifier in the same way.</p>
 <p>For meaningful groups of documents you can also use the document <ref target="corpora">corpus</ref> grouping</p>
 <p>In case your text is in an <gi>additions</gi> <gi>item</gi> and it is composed of different sections,

--- a/pages/Narratives.xml
+++ b/pages/Narratives.xml
@@ -21,26 +21,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
         <change who="PL" when="2018-04-30">first version of guidelines from Wiki</change>
         <change who="PL" when="2019-02-28">added links, split into three parts to define most common uses of the Narrative Unit</change>
+          <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
       </revisionDesc>
     </teiHeader>
     <text>
         <body xml:id="narrativeUnits">
             <div type="level1">
     <head>Narrative Units</head>
-                <p>The model file for a <ref target="definitionWorks">Narrative Unit</ref> is much
-                  simpler than a <ref target="works">work file</ref>. Just assign a
-        title to your file and add in the <gi>body</gi> a short
-        description. You can mark up content as in any other entity.
-        Recommended but not compulsory are a bibliography and a
-        <gi>listRelation</gi>.</p>
-        <p>A Narrative Unit can be pointed to in any place where you can point to a <ref target="definitionWorks">Textual Unit</ref>.
+              <p>The model file for a <ref target="definitionWorks">Narrative Unit</ref> is similar to a 
+                <ref target="works">Work file</ref>, but somehow simpler. Just assign a
+                title to your file and add in the <gi>body</gi> a short
+                description. You can mark up content as in any other entity.
+                Recommended but not compulsory are a bibliography and a
+                <gi>listRelation</gi>.</p>
+        <p>A Narrative Unit can be pointed to in any place where you can point to a <ref target="definitionWorks">Work</ref>.
           The following are some examples of the main types of use</p>
         <div type="level2">
           <head>Narrative Units in the main content</head>
           <p>
             In the following example from
             <ref type="BM" target="BLadd16217">London, British Library, BL Add. 16,217</ref>
-            a main content of the manuscript could not be identified with a Textual Unit. It has been associated with a Narrative Unit
+            a main content of the manuscript could not be identified with a Work. It has been associated with a Narrative Unit
           instead.
           </p>
           <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -50,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 ...
             </msItem>
           </egXML>
-          <p>This is the same which you would do for a Textual Unit (see the page on <ref target="manuscriptContents">manuscript contents</ref>).</p>
+          <p>This is the same which you would do for a Work (see the page on <ref target="manuscriptContents">manuscript contents</ref>).</p>
           <p>In the following example from
             <ref target="BDLbruce93">Oxford,
               Bodleian Library, Bodleian Bruce 93</ref>
@@ -76,7 +77,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <head>Narrative Units in quaternary strata</head>
             <p>
               <ref target="documents">The page about documents</ref>
-              gives some examples of how to use Narrative Units and Textual Units to identify a content.
+              gives some examples of how to use Narrative Units and Work to identify a content.
               This will happen basically in the same way as in the above example, with a <gi>title</gi> element.
             </p>
             </div>

--- a/pages/additionsVaria.xml
+++ b/pages/additionsVaria.xml
@@ -24,6 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2018-05-23">Added paragraph on handNotes</change>
             <change who="PL" when="2018-06-18">Added summary of Issue 917</change>
             <change who="DR" when="2018-08-03">Added encoding of owners in varia</change>
+            <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -107,7 +108,7 @@ never be used to mark a content, that presupposes another perspective.</p>
                     <val>guardLeaf</val>.</p>
                 <p>If the type of document is known, then there should be a
                     value in the <att>type</att> of the element <gi>desc</gi>.
-                    Additionally, if the content is identifiable with a Textual or Narrative Unit, this can be specified, adding <gi>title</gi> element with a <att>ref</att> in <gi>desc</gi>.
+                    Additionally, if the content is identifiable with a Work or with a Narrative Unit, this can be specified, adding <gi>title</gi> element with a <att>ref</att> in <gi>desc</gi>.
                   </p>
                 <p>More examples are provided in the page about <ref target="documents">documents</ref>.
                   The following example, from <ref target="BLorient494" type="BM">London, British Library, BL Oriental 494</ref> shows
@@ -175,7 +176,7 @@ never be used to mark a content, that presupposes another perspective.</p>
                   the text in its correct position as non-literary.
                   We have in the category of keywords for Subjects, for example, "Other" but also "Legal Document".
                   If a given textual unit is, according to the definition in the schema, a
-                  Donation Note or a Letter, you can add that keyword to the work record.</p>
+                  Donation Note or a Letter, you can add that keyword to the Work record.</p>
 <p>If the text is a primary strata and we happen to have also manuscripts where this text is an addition,
   then you could add a <gi>relation</gi> (e.g. with  <val>saws:isCopyOf</val> for <att>name</att>) which connects the <gi>msItem</gi> with the addition in question.</p>
                 <p>In additions as anywhere in the manuscript description, a <gi>handNote</gi> should be created for each identifiable hand, whether it can be described from available pictures of the manuscript
@@ -245,7 +246,7 @@ trials, notes crudely written in pencil or pen;</item>
                     <p>See also <ref target="text-encoding">Text Encoding</ref>.</p>
 
                     <p>Information provided in the catalogue which would ideally be marked-up directly in a transcribed text, such as the names of owners or patrons mentioned in supplications or elsewhere,
-                    can also be recorded in Varia if the textual context is not provided by the catalogue:
+                    can also be recorded in Varia, if the textual context is not provided by the catalogue:
                         <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <item xml:id="e1">
                             <locus target="#1r"/>

--- a/pages/create.xml
+++ b/pages/create.xml
@@ -17,7 +17,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <p></p>
          </sourceDesc>
       </fileDesc>       <revisionDesc>
-        <change who="PL" when="2019-11-20">Created file</change></revisionDesc>
+        <change who="PL" when="2019-11-20">Created file</change>
+         <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
+      </revisionDesc>    
    </teiHeader>
    <text>
       <body xml:id="create">
@@ -27,6 +29,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <p>If you are not, ask to be added.</p>
         <p>You can always check the data and add in the folder called "new" correct and validating files which adhere to these guidelines, with one exception:
           <ref target="Works">Work</ref> records can only be created in the application because their IDs become CAe identifiers.</p>
+   <!-- Is it only Work records, that are created through the app? PRS and LOC are created through the app and receive their own CAe identifiers as well. -->
         <p>Please follow the instructions given on the application after the creation of a new file with that procedure. After downloading and before committing
          the new file, always open it in your editor to make sure that it is valid and, if necessary (which it nearly always is!), edit it.</p>
 </div>
@@ -35,29 +38,29 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <p>It is not rare that a single unit of work will involve several commits to several branches of different repositories. Here is an example:</p>
             <list rend="ordered">
                <item>The contributor starts to edit a manuscript record,</item>
-               <item>she thinks an identifier for a new Textual Unit is needed,</item>
-            <item> she      opens an issue, labeled Textual Unit Identification, pings relevant people and 
-               makes sure that this new Textual Unit should be created  
+               <item>she thinks an identifier for a new Work is needed,</item>
+            <item> she opens an issue, labeled 'Text Identification', pings relevant people and 
+               makes sure that this textual unit should be created as a new Work file or Narrative unit file  
                (this also helps contributors who do not have enough permissions to 
-               create Textual Units in the app). In the while, there is no need to add a <att>ref</att> to
+               create Works or Narrative units in the app). In the while, there is no need to add a <att>ref</att> to
             <gi>title</gi> in <gi>msItem</gi> in the manuscript record, for example, a comment can be left that there is a pending issue about the 
-               identification of the Textual Unit.</item>
+               identification of this text part.</item>
               <item> 
                  If the result of the discussion is positive and a new record is needed,
-                 the editor or some other collaborator creates it in the app (it needs to, is a textual unit!).</item>
+                 the editor or some other collaborator creates it in the app.</item>
               <item> 
-                 Because the Textual Unit record has been created in the app, it needs to be synced.
+                 Because the Work record or the Narrative unit record has been created in the app, it needs to be synced.
                  Make a Pull Request to Works repository and make sure it is promptly reviewed, corrected and merged. 
                  Planning this 
                  in the issue where you discussed the creation is a good idea.
                  Please note that it needs to be merged quickly, to keep the app in sync.
               </item> 
                <item>Anyone can now use the newly created 
-                  Textual Unit ID in  manuscript records.
+                  Work ID or Narrative unit ID in  manuscript records.
               </item> 
                <item>Once the contributor is ready, a Pull Request for the manuscript can be done to the Manuscripts repository.
                </item>
-               <item>During review it turns out it was not necessary to create a Textual Unit, alas. A collaborator reviewing this Pull Request did not see the discussion and could not intervene before.
+               <item>During review it turns out it was not necessary to create a Work ID, alas. A collaborator reviewing this Pull Request did not see the discussion and could not intervene before.
                </item>
                <item>The editor or any other collaborator can now delete the 
                   record in the Works repository and make a Pull Request justified by the
@@ -69,14 +72,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                commit and a Pull Request to align to the database in any case. If the discussion about this 
                operation has already happened, review only needs to focus on typos and contents of the record.
               The app will have learned about the new files because they were created in there 
-              in the first place, but if you do not merge them into master, as a result of a Pull Request and delete them
+              in the first place. But if you do not merge them into master, as a result of a Pull Request and delete them,
               the app will never get to know that the record was deleted 
-              because you deleted it somewhere else. 
+              (because you deleted it somewhere else). 
               That is why we need a commit and a Pull Request, so that repository and database stay in sync.</p>
          </div>
          <div type="level1">
             <head>Doublets</head>
-            <p>Doublets may be identified. This happens especially when Textual Units are created without enough disambiguation information
+            <p>Doublets may be identified. This happens especially when Works are created without enough disambiguation information
             or when one same manuscript is entered in the system from different sources without prior knowledge 
             and due diligence to identify the already existing record. It is, however, normal and will always happen.</p>
             <p>If you identify a doublet, it is wise to deal with it in some way or another 
@@ -107,7 +110,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <head>Delete</head>
             <p>If you make a mistake or find a doublet 
                which needs to be cleaned up or need 
-               to <ref target="definitionWorks">reorganize Textual Units</ref> by making one formerly independent 
+               to <ref target="definitionWorks">reorganize Works</ref> by making one formerly independent 
                part of another, you will delete a record. 
             Doing so as you do normally, with a commit to the 
             public repositories in GitHub, 

--- a/pages/definitionWorks.xml
+++ b/pages/definitionWorks.xml
@@ -21,7 +21,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
         <change who="DR" when="2018-04-26">editing of the Work section of the guidelines</change>
             <change who="PL" when="2018-04-30">first version of guidelines from Wiki</change>
-         <change who="DR" when="2019-11-08">minor edits according to Alessandro Bausi's corrections</change></revisionDesc>
+         <change who="DR" when="2019-11-08">minor edits according to Alessandro Bausi's corrections</change>
+         <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
+      </revisionDesc>
    </teiHeader>
    <text>
       <body xml:id="definitionWorks">
@@ -72,7 +74,7 @@ is not a work, it is a part of the work
                     <label>Anaphora of Mary</label>
                     </div>
                   </egXML>
-                  The text is then identified as a textual unit but also as part of the text where it is contained with reference to its independent ID. 
+                  The text is then identified as a Work in its own right, as well as being referenced by another ID within the text in which it is contained. 
                   This corresponds to making a statement as
                   <egXML xmlns="http://www.tei-c.org/ns/Examples">
                     <relation active="LIT1960Mashaf" name="saws:contains" passive="LIT1099Anapho"/>

--- a/pages/editionworkflow.xml
+++ b/pages/editionworkflow.xml
@@ -18,8 +18,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
-
       <change who="PL" when="2021-11-18">first version from test run on LIT4714</change>
+      <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
     </revisionDesc>
   </teiHeader>
   <text>
@@ -99,12 +99,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             case you do not, <ref target="https://betamasaheft.eu/">Beta maṣāḥǝft</ref> may help
             you. Search for the title of your work, open the relevant work, and on the right, in
             red, you will find a list of manuscripts, sorted by type of content and eventually also
-            telling you about other textual units related to the one you are looking for.</p>
+            telling you about other Works or Narrative units related to the one you are looking for.</p>
           <p>This kind of search may not however bring you to the digital surrogates directly. <ref
               target="https://betamasaheft.eu/availableImages.html">The project also maintains a
               list of available images.</ref></p>
           <p>Because who writes does not have a clue, he looked with a script in the data searching
-            for a textual unit attested in manuscripts with a likelihood to have accessible images.
+            for a Work attested in manuscripts with a likelihood to have accessible images.
             Below is the script, just because it is always nice. It looks in the Ethio-SpaRE
             manuscripts, and selects only identified and encoded texts which occur 5 times in
             manuscripts whose images are available online (<gi>idno</gi> has both <att>facs</att>
@@ -146,10 +146,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
               environment? Consider as a first step having a unified source of information, thus
               describing the manuscripts and linking the images and the text in the research
               environment. <ref target="manuscripts">Catalogue descriptions</ref> can be long or
-              short there are no requirement. What is then important is that you link your textual
-              unit to the description, as a <ref target="manuscriptContents">main content</ref> or
-                <ref target="additionsVaria">addition</ref>. If in doing this you also add a
-              description, links to other named entities and relevant bibliography, all will be able
+              short there are no requirements. What is then important is that you link your identified textual unit with its Work ID
+              to the description, as a <ref target="manuscriptContents">main content</ref> or
+                <ref target="additionsVaria">addition</ref>. If doing this you also add a
+              description, links to other named entities and relevant bibliography. Everybody will be able
               to benefit from that. If you do not want to do so, you can still list witnesses which
               are external to BM. If these have accessible images and data, link them. However, the
               PDF script listed in this page will not work out of the box, can be adapted
@@ -158,8 +158,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </div>
         <div type="level2">
           <head>Transcription</head>
-          <p>You may be very lucky and find out we have already added a transcription based on the
-            images, but this is not a very frequent case. Let us assume that there is no
+          <p>You might be lucky enough to find that we have already added a transcription based on the images, 
+            but this doesn't happen very often. Let us assume that there is no
             transcription, as for my example. I located the text using the viewer for each
             manuscript and downloaded the relevant photos following the manifest links. This may be
             not possible for you, please, simply ask. I then asked a colleague, Solomon, to help me
@@ -216,9 +216,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
               >You could start from here</ref>.</p>
           <p>I did a branch of the Manuscripts repository and opened the four relevant files for the
             manuscripts.</p>
-          <p>I did a branch of the Works repository and opened the textual unit of the text.</p>
-          <p>I then copied from the TEI output of transrkibus into the BM manuscript records and
-            encoded the text structure. I used for this step the Atom editor. Any other is ok.</p>
+          <p>I created a branch of the Works repository and opened the Work record of the text.</p>
+          <p>I then copied the text from the TEI output of Transkribus into the BM manuscript records,
+            encoding the text structure in the process. For this step, I used the Atom editor. Any other editor is OK.</p>
           <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <div type="edition" xml:lang="gez">
               <div type="textpart" subtype="folio" n="9">
@@ -248,7 +248,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
               corrections, normalizations</ref>, etc. The correction of the text can be done in
             transkribus before exporting or in the TEI of the manuscript. If done in transkribus
             only visible text should be entered. Markup will be added in the TEI. Once correction
-            and encoding took place the text in the mss will look like the following example, more
+            and encoding took place the text in the Manuscripts will look like the following example, more
             or less.</p>
           <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <div type="edition" xml:lang="gez">

--- a/pages/references.xml
+++ b/pages/references.xml
@@ -21,7 +21,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <revisionDesc>
          <change who="PL" when="2018-04-30">first version of guidelines from Wiki</change> 
          <change who="PL" when="2020-06-16">introduced text and example for referencing 
-         based on DTS navigation and document support</change>     
+         based on DTS navigation and document support</change>
+         <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -130,7 +131,7 @@ This manuscript is in the same hand as <ref type="hand" corresp="ESap002#h2"/>
                <div type="level4">
                   <head>First part (identifier)</head>
                <p><code>ID</code></p>
-                  <p>This is the ID of the manuscript or textual unit, <ref target="entities-id-structure">as normally used</ref>.
+                  <p>This is the ID of the Manuscript, Work or Narrative unit, <ref target="entities-id-structure">as normally used</ref>.
                Anchors are inconsistent with the aim of this structured referencing system and alternative to it. 
                The following example is what is discussed here, as a pointer to a specific passage in the text TUid123 at a subdivision named 1 which is 
                child of another subdivision named 1.

--- a/pages/relations.xml
+++ b/pages/relations.xml
@@ -25,6 +25,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <change who="DR" when="2020-03-05">Corrected typos</change>
             <change who="DR" when="2022-07-07">updated use of several relations according to discussion in 
                 https://github.com/BetaMasaheft/Documentation/issues/1920 and https://github.com/BetaMasaheft/Documentation/issues/1350</change>
+            <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -102,12 +103,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 is reserved for marking the relation between a deleted record and a record which 
                 contains information formerly described in that<ref target="create"> deleted record</ref>.</p>
 
-                <p><code>lawd:hasAttestation</code> is used to say that a named entity, a person, a
-                    place, a textual unit is attested in a textual unit or a manuscript or one of
-                    its parts. It cannot be used to relate persons to persons or persons to places,
+                <p><code>lawd:hasAttestation</code> is used to say that a named entity, a Person, a
+                    Place, a Work is attested in a Work or a Manuscript or one of
+                    its parts. It cannot be used to relate Person to Person or Person to Place,
                     and so on. This also means that if you are working on a set of records and do not want to
                 touch the manuscripts, either start writing a list of witnesses, you can use this relation to say
-                that a textual unit is present in a manuscript.</p>
+                that a work is present in a manuscript.</p>
                 
                 <p>
                     <code>syriaca:different-from</code> can be used to differentiate any two entitites from each other except
@@ -188,7 +189,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </div>
             <div type="level2">
                 <head>Work to Work</head>
-                <p><code>saws:formsPartOf</code> is used to declare that a defined Textual Unit is
+                <p><code>saws:formsPartOf</code> is used to declare that a defined Work is
                     always part of another one. <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <relation name="saws:formsPartOf" active="LIT3854KingList"
                             passive="LIT1507GadlaT">
@@ -237,8 +238,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </relation>
                     </egXML>
                 </p>
-                <p><code>saws:contains</code> can be used if you are sure that a textual unit always
-                    contains another textual unit (the latter may circulate also independently).
+                <p><code>saws:contains</code> can be used if you are sure that a Work always
+                    contains another Work (the latter may circulate also independently).
                         <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <relation name="saws:contains" active="LIT2317Senodo" passive="LIT2696Hom"/>
                     </egXML>
@@ -271,8 +272,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </egXML>
                 </p>
                 <p>
-                    <code>ecrm:P129_is_about</code> is used to say that a Textual Unit speaks about
-                    another Textual Unit. <egXML
+                    <code>ecrm:P129_is_about</code> is used to say that a Work speaks about
+                    another Work. <egXML
                         xmlns="http://www.tei-c.org/ns/Examples">
                         <relation name="ecrm:P129_is_about" active="LIT5327MiracleVisit"
                             passive="LIT3575Mashaf"/>
@@ -405,7 +406,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </div>
             <div type="level2">
                 <head>Work to Person</head>
-                <p><code>saws:isAttributedToAuthor</code> is used to state that a Textual Unit has
+                <p><code>saws:isAttributedToAuthor</code> is used to state that a Work has
                     been attributed to a person. <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <relation name="saws:isAttributedToAuthor" active="LIT1287Dersan"
                             passive="PRS9481Theodoto">
@@ -426,7 +427,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             passive="PRS9167TaklaHa"/>
                     </egXML>
                 </p>
-                <p><code>ecrm:P129_is_about</code> is used to state a subject of a Textual Unit.
+                <p><code>ecrm:P129_is_about</code> is used to state a subject of a Work.
                         <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <relation name="ecrm:P129_is_about" active="LIT5284MiracleDawit"
                             passive="PRS3429DawitII">

--- a/pages/text-encoding.xml
+++ b/pages/text-encoding.xml
@@ -24,6 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="DR" when="2019-12-09">Added line take-up/down information, small edits for readability</change>
          <change who="DR" when="2020-11-20">Added explanations on text in work and manuscript records from Pietro
             Liuzzo's and Daria Elagina's remarks in https://github.com/BetaMasaheft/Documentation/issues/1570</change>
+         <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -831,7 +832,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
    <head>Translations</head>
    <p>As there is a <tag>div type='edition'</tag> there can be a <tag>div type='translation'</tag>, a feature inherited 
       from the main structural <gi>div</gi>s of an edition from the <ref target="https://epidoc.stoa.org/gl/latest/supp-translation.html">EpiDoc Guidelines</ref>. 
-      You can add this beside your <tag>div type='edition'</tag> in any manuscript or textual unit file where you want to provide a translation. 
+      You can add this beside your <tag>div type='edition'</tag> in any Manuscript or Work file where you want to provide a translation. 
       To align parts of the translation to parts of the text, edition or transcription, you can use standard linking practices, that is to say, point to the correct <att>xml:id</att>.</p>
    <p>The following example is taken from <ref type="BM" target="LIT5064HEpA">History of the Episcopate of Alexandria</ref>.</p>
    <egXML xmlns="http://www.tei-c.org/ns/Examples">

--- a/pages/trainingmaterials.xml
+++ b/pages/trainingmaterials.xml
@@ -25,6 +25,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <change who="PL" when="2021-05-20">Added new slideshows</change>
       <change who="ES" when="2022-04-20">Added 2022 Hamburg workshop link, PP link</change>
       <change who="DR" when="2022-12-21">Added 2022 Marburg presentations</change>
+      <change who="CH" when="2025-07-01">Update according to our discussion in Issue #1918 (Replace 'Textual Unit')</change>
     </revisionDesc>
   </teiHeader>
   <text>
@@ -358,7 +359,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
           </row>
 
           <row>
-            <cell>Encoding of manuscripts' content and textual units</cell>
+            <cell>Encoding of manuscripts' content (Works and Narrative Units)</cell>
             <cell>description</cell>
             <cell></cell>
             <cell>


### PR DESCRIPTION
I changed the term "textual unit" to "Work" or to "Work or Narrative Unit" to make it more clear according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/1918#issuecomment-3009520168. I kept the "textual units" only in a few cases as for instance in create.xml in the paragraph on text identification (Example workflow) because I felt in this case, that the term is justified since it refers to a case, when it is not certainly clear whether a text can be identified as Work, Narrative unit or none of that.

I updated some terms to capitalised terms, because I felt, that this is the dominant method. However, I did not do this systematically in all records in this pull request.

I have commented out some details, that possibly need some modification in other pull requests.