### PR TITLE
fix(expath-pkg.xml): do not build broken expath-pkg.xml files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,22 +15,30 @@
         <delete dir="${build.dir}" failonerror="false" />
     </target>
 
-    <target name="templates" description="process template files" depends="clean,git.revision">
-        <echo message="Creating build folder..." />
-        <mkdir dir="${build.dir}" />
-        <echo>Update Version with: ${app.version}</echo>
-        <copy todir="${build.dir}" verbose="true">
-            <fileset file="repo.xml" />
-            <fileset file="expath-pkg.xml" />
-            <filterchain>
-                <replacetokens>
-                    <token key="version" value="${app.version}" />
-                    <token key="commit-id" value="${git.revision}" />
-                    <token key="commit-time" value="${git.time}" />
-                </replacetokens>
-            </filterchain>
-        </copy>
-    </target>
+	<target name="templates" description="process template files"  depends="clean,git.revision">
+      <echo message="Creating build folder..." />
+      <mkdir dir="${build.dir}" />
+      <echo>Update Version with: ${app.version}</echo>
+      <copy todir="${build.dir}" verbose="true">
+		<fileset file="repo.xml" />
+		<fileset file="expath-pkg.xml" />
+		<filterchain>
+          <replacetokens>
+			<token key="commit-id" value="${git.revision}" />
+			<token key="commit-time" value="${git.time}" />
+          </replacetokens>
+
+		  <!--
+			  Replace the 'version="1.0"' string in the expath-pkg.xml with the correct version. Do
+			  not use normal token replacement for this since the regular token approach (%version%)
+			  is forbidden in expath-pkg.xml. Instead, replace version=".*", but not in the XML header
+		  -->
+		  <replaceregex
+			  pattern="(?&lt;!xml )version=&quot;.*&quot;"
+			  replace="version=&quot;${app.version}&quot;" />
+		</filterchain>
+      </copy>
+	</target>
 
     <target name="xar" depends="clean,templates" description="create xar file">
         <echo message="------------------------------------------------------------" />

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://betamasaheft.aai.uni-hamburg.de/guidelines-data/" abbrev="guide-data" version="@version@" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://betamasaheft.aai.uni-hamburg.de/guidelines-data/"
+  abbrev="guide-data" spec="1.0" version="1.0.0">
     <title>Guidelines (Data)</title>
     <dependency processor="http://exist-db.org" semver-min="5.2.0"/>
     <rng>
         <import-uri>https://betamasaheft.eu/guidelines.rng</import-uri>
-        <file>schema/out/tei-betamesaheftGL.rng</file>              
+        <file>schema/out/tei-betamesaheftGL.rng</file>
     </rng>
 </package>


### PR DESCRIPTION
The @version@ is forbidden for expath packages. This way we always have a valid version in our hands